### PR TITLE
Feature/addon v1.1

### DIFF
--- a/addon/CHANGELOG.md
+++ b/addon/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Version 1.1
+* Set inital values of mqtt_user and mqtt_password to null instead of dummy values to ensure that user enters them
+* Added debug variable to allow start of container and then manual connection to it to run commands
+* Added netcat test to check that Outlander is available
+* Moved phev2mqtt binary from /tmp/phev2mqtt to /opt
+
+# Version 1
+Initial build

--- a/addon/Dockerfile
+++ b/addon/Dockerfile
@@ -1,0 +1,25 @@
+ARG BUILD_FROM
+FROM $BUILD_FROM as builder
+
+RUN apk update && apk add --no-cache \
+	g++ \
+	gcc \
+	git \
+	libpcap-dev
+
+WORKDIR /tmp
+RUN git clone https://github.com/buxtronix/phev2mqtt.git
+COPY --from=golang:alpine /usr/local/go/ /usr/local/go/
+RUN cd /tmp/phev2mqtt && \
+    /usr/local/go/bin/go build
+
+FROM $BUILD_FROM
+RUN apk update && apk add --no-cache \
+	libpcap-dev
+
+COPY --from=builder /tmp/phev2mqtt/phev2mqtt /tmp/phev2mqtt/phev2mqtt
+
+COPY run.sh /opt
+RUN chmod a+x /opt/run.sh
+
+CMD [ "/opt/run.sh" ]

--- a/addon/Dockerfile
+++ b/addon/Dockerfile
@@ -17,7 +17,7 @@ FROM $BUILD_FROM
 RUN apk update && apk add --no-cache \
 	libpcap-dev
 
-COPY --from=builder /tmp/phev2mqtt/phev2mqtt /tmp/phev2mqtt/phev2mqtt
+COPY --from=builder /tmp/phev2mqtt/phev2mqtt /opt/phev2mqtt
 
 COPY run.sh /opt
 RUN chmod a+x /opt/run.sh

--- a/addon/README.md
+++ b/addon/README.md
@@ -1,0 +1,16 @@
+This requires that the local wifi is already connected to the Outlander, you should be able to check this by ensuring that you have a 192.168.8.x IP address
+
+Once installed as a local addon, you can configure the mqtt target and username/password and then start and stop phev2mqtt from the GUI
+
+These files need to go in a directory (called phev for example) in the local addons.
+
+If you ssh into the main os, this will be in /usr/share/hassio/addons/local/phev
+If you ssh in using the terminal add on, this will be /addons/phev (or symblink /root/addons/phev)
+If you connect to the hassio_supervisort docker container, this will be /data/addons/local/phev
+
+More information about local addons at https://developers.home-assistant.io/docs/add-ons/tutorial/
+
+NOTE - on 32bit Raspberry Pi there's an issue with the latest alpine docker images and old versions of libseccomp (including the ones in Raspbian repos), this will stop the Dockerfile building. In order to overcome this, you may need to manually install a newer version with
+
+    wget http://ftp.us.debian.org/debian/pool/main/libs/libseccomp/libseccomp2_2.4.4-1~bpo10+1_armhf.deb
+    dpkg -i libseccomp2_2.4.4-1~bpo10+1_armhf.deb

--- a/addon/config.json
+++ b/addon/config.json
@@ -1,6 +1,6 @@
 {
   "name": "PHEV",
-  "version": "1",
+  "version": "1.1",
   "slug": "phev",
   "description": "Mitsubishi PHEV",
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
@@ -9,12 +9,14 @@
   "host_network": true,
   "options": {
     "mqtt_server": "localhost:1883",
-    "mqtt_user": "mqtt_username",
-    "mqtt_password": "secret_password"
+    "mqtt_user": null,
+    "mqtt_password": null,
+    "debug": false
   },
   "schema": {
     "mqtt_server": "str",
     "mqtt_user": "str",
-    "mqtt_password": "str"
+    "mqtt_password": "str",
+    "debug": "bool"
   }
 }

--- a/addon/config.json
+++ b/addon/config.json
@@ -1,0 +1,20 @@
+{
+  "name": "PHEV",
+  "version": "1",
+  "slug": "phev",
+  "description": "Mitsubishi PHEV",
+  "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
+  "startup": "before",
+  "boot": "auto",
+  "host_network": true,
+  "options": {
+    "mqtt_server": "localhost:1883",
+    "mqtt_user": "mqtt_username",
+    "mqtt_password": "secret_password"
+  },
+  "schema": {
+    "mqtt_server": "str",
+    "mqtt_user": "str",
+    "mqtt_password": "str"
+  }
+}

--- a/addon/run.sh
+++ b/addon/run.sh
@@ -5,8 +5,28 @@ CONFIG_PATH=/data/options.json
 export mqtt_server="$(bashio::config 'mqtt_server')"
 export mqtt_user="$(bashio::config 'mqtt_user')"
 export mqtt_password="$(bashio::config 'mqtt_password')"
+export debug="$(bashio::config 'debug')"
 
-/tmp/phev2mqtt/phev2mqtt \
+if [[ $debug == "true" ]]
+then
+	echo Debug mode on - sleeping indefinitely
+	sleep inf
+fi
+
+#Test to see if we can connect to the Outlander
+nc -zw 1 192.168.8.46 8080
+RC=$?
+
+if [[ $RC -ne  0 ]]
+then
+	echo Connection to Outlander unsuccessful
+	exit 1
+fi
+
+echo Connection to Outlander successful
+echo Starting phev2mqtt
+
+/opt/phev2mqtt \
         client \
         mqtt \
         --mqtt_server "tcp://${mqtt_server}/" \

--- a/addon/run.sh
+++ b/addon/run.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/with-contenv bashio
+
+CONFIG_PATH=/data/options.json
+
+export mqtt_server="$(bashio::config 'mqtt_server')"
+export mqtt_user="$(bashio::config 'mqtt_user')"
+export mqtt_password="$(bashio::config 'mqtt_password')"
+
+/tmp/phev2mqtt/phev2mqtt \
+        client \
+        mqtt \
+        --mqtt_server "tcp://${mqtt_server}/" \
+        --mqtt_username "${mqtt_user}" \
+        --mqtt_password "${mqtt_password}"
+


### PR DESCRIPTION
# Version 1.1
* Set inital values of mqtt_user and mqtt_password to null instead of dummy values to ensure that user enters them
* Added debug variable to allow start of container and then manual connection to it to run commands
* Added netcat test to check that Outlander is available
* Moved phev2mqtt binary from /tmp/phev2mqtt to /opt