### PR TITLE
Protocol: Do not XOR the MY'14 start commands/responses

### DIFF
--- a/protocol/message.go
+++ b/protocol/message.go
@@ -76,7 +76,7 @@ func (p *PhevMessage) ShortForm() string {
 		return fmt.Sprintf("START SEND18  (orig  %s)", hex.EncodeToString(p.Original))
 
 	case CmdInStartResp:
-		return fmt.Sprintf("START RESP18  (orig: %s)", hex.EncodeToString(p.Original))
+		return fmt.Sprintf("START RESP    (orig: %s)", hex.EncodeToString(p.Original))
 
 	case CmdOutSend:
 		if p.Ack == Ack {
@@ -94,13 +94,13 @@ func (p *PhevMessage) ShortForm() string {
 		return fmt.Sprintf("START RECV18  (orig %s)", hex.EncodeToString(p.Original))
 
 	case CmdOutMy18StartResp:
-		return fmt.Sprintf("START SEND    (orig %s)", hex.EncodeToString(p.Original))
+		return fmt.Sprintf("START SEND18  (orig %s)", hex.EncodeToString(p.Original))
 
 	case CmdInMy14StartReq:
-		return fmt.Sprintf("START RECV 14 (orig %s)", hex.EncodeToString(p.Original))
+		return fmt.Sprintf("START RECV14  (orig %s)", hex.EncodeToString(p.Original))
 
 	case CmdOutMy14StartResp:
-		return fmt.Sprintf("START SEND 14 (orig %s)", hex.EncodeToString(p.Original))
+		return fmt.Sprintf("START SEND14  (orig %s)", hex.EncodeToString(p.Original))
 
 	case CmdInBadEncoding:
 		return fmt.Sprintf("BAD ENCODING  (exp: 0x%02x)", p.Data[0])

--- a/protocol/message.go
+++ b/protocol/message.go
@@ -126,7 +126,7 @@ func (p *PhevMessage) EncodeToBytes(key *SecurityKey) []byte {
 	data = append(data, Checksum(data))
 	var xor byte
 	switch p.Type {
-	case CmdInMy18StartReq, CmdOutMy18StartResp:
+	case CmdInMy18StartReq, CmdOutMy18StartResp, CmdInMy14StartReq, CmdOutMy14StartResp:
 		// No xor/key for these messages.
 	case CmdOutSend:
 		// Use then increment send key.


### PR DESCRIPTION
This allows `phev2mqtt` to successfully interact with my MY'14. This was broken in 3db6f8370ae9f62f987f2260b96ed5cae32838ac. I believe the following issues are relevant and should probably be retested after merging this:

* #23 
* #24 