### PR TITLE
Protocol: Do not set remaining charge time if MSB is 0xff

### DIFF
--- a/protocol/message.go
+++ b/protocol/message.go
@@ -452,18 +452,9 @@ func (r *RegisterChargeStatus) Decode(m *PhevMessage) {
 		return
 	}
 	r.Charging = m.Data[0] == 0x1
-	if r.Charging {
-		high := int(m.Data[1])
-		low := int(m.Data[2])
-		if low < 0 {
-			low += 0x100
-		}
-		low *= 0x100
-
-		if high < 0 {
-			high += 0x100
-		}
-		r.Remaining = low + high
+	r.Remaining = 0
+	if m.Data[2] != 0xff {
+		r.Remaining = int((m.Data[2] << 8) | m.Data[1])
 	}
 	r.raw = m.Data
 }


### PR DESCRIPTION
This value is a little-endian `(u?)int16` and the most significant byte can sometimes be set to `0xff`, which on my MY'14 car most likely means something like "it's charging, but the remaining time is unknown". This value occurs when I leave the charging plug connected and remotely activate the heater. After some time, the `0xff` byte disappears and a sensible remaining charge time appears.

This behavior reflects what `phevcore` does as well.