### PR TITLE
Use 0x10 for AC state

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ The following topics are subscribed to and can be used to change state on the ca
 | phev/set/headlights | Set head lights *on* or *off* |
 | phev/set/cancelchargetimer | Cancel charge timer (any payload) |
 | phev/set/climate/[mode] | Set ac/climate state (cool/heat/windscreen/off) for [payload] (10[on]/20/30) |
+| phev/set/climate/state | `[payload]=reset` clears "terminated" state |
 | phev/connection | Change car connection state to (on/off/restart) |
 
 #### Home Assistant discovery

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -331,17 +331,20 @@ __must be converted from big endian to little endian__ to be useful
 | 18       | off                                         |
 | 19-23    | Unknown (unused?)                           |
 
-### 0x10 - Aircon status
+### 0x10 - Preconditioning status
 
 3 bytes.
 
 | Byte(s) | Description |
-|--|--|
-|0 | Unknown |
-| 1 | AC operating [0=off 1=on] |
+|---------|-------------|
+| 0 | Preconditioning state [0 = off, 2 = on, 3 = cancelled by open door/low battery] |
+| 1 | Unknown |
 | 2 | Unknown |
 
 02b00b = windscreen on/10min
+026e09 = windscreen on/10min (on another vehicle)
+030000 = after door openining
+000000 = precondition not active/terminated normally (e.g. timer elapsed.)
 
 ### 0x12 - Car time sync
 
@@ -446,6 +449,7 @@ A string with the software version of the ECU.
 | 0xe      | Save settings??            | Sent after 0xf command |
 | 0xf      | Update settings            |                        |
 | 0x10     | Register Wifi client       | 0x1                    |
+| 0x13     | Reset PreAC state          | 0x1                    |
 | 0x15     | Unregister Wifi client     | 0x1                    |
 | 0x1a     | Set climate timer          | See below              |
 | 0x1b     | Set climate state          | See below              |

--- a/protocol/message.go
+++ b/protocol/message.go
@@ -180,8 +180,8 @@ func (p *PhevMessage) DecodeFromBytes(data []byte, key *SecurityKey) error {
 			p.Reg = new(RegisterChargePlug)
 		case ChargeStatusRegister:
 			p.Reg = new(RegisterChargeStatus)
-		case ACOperStatusRegister:
-			p.Reg = new(RegisterACOperStatus)
+		case PreACStateRegister:
+			p.Reg = new(RegisterPreACState)
 		case ACModeRegister:
 			p.Reg = new(RegisterACMode)
 		default:
@@ -234,18 +234,20 @@ func NewFromBytes(data []byte, key *SecurityKey) []*PhevMessage {
 }
 
 const (
-	VINRegister              = 0x15
-	ECUVersionRegister       = 0xc0
-	BatteryLevelRegister     = 0x1d
 	BatteryWarningRegister   = 0x02
-	DoorStatusRegister       = 0x24
-	ChargeStatusRegister     = 0x1f
-	ACOperStatusRegister     = 0x1a
-	SetACEnabledRegisterMY14 = 0x04
 	SetACModeRegisterMY14    = 0x02
+	SetACEnabledRegisterMY14 = 0x04
+	PreACStateRegister       = 0x10
+	SetAckPreACTermRegister  = 0x13
+	VINRegister              = 0x15
 	SetACModeRegisterMY18    = 0x1b
 	ACModeRegister           = 0x1c
+	BatteryLevelRegister     = 0x1d
 	ChargePlugRegister       = 0x1e
+	ChargeStatusRegister     = 0x1f
+	LightStatusRegister      = 0x23
+	DoorStatusRegister       = 0x24
+	ECUVersionRegister       = 0xc0
 )
 
 type Register interface {
@@ -477,34 +479,42 @@ func (r *RegisterChargeStatus) Register() byte {
 	return ChargeStatusRegister
 }
 
-type RegisterACOperStatus struct {
-	Operating bool
+type PreACState int8
+
+const (
+    PreACOff PreACState = 0
+    PreACOn PreACState = 2
+    PreACTerminated PreACState = 3
+)
+
+type RegisterPreACState struct {
+	State     PreACState
 	raw       []byte
 }
 
-func (r *RegisterACOperStatus) Decode(m *PhevMessage) {
-	// MY'18 data length is 5 bytes, MY'14 uses 2 bytes
-	// We only decode the operating state in byte 2
-	if m.Register != ACOperStatusRegister || len(m.Data) < 2 {
+func (r *RegisterPreACState) Decode(m *PhevMessage) {
+	if len(m.Data) < 3 {
 		return
 	}
-	r.Operating = m.Data[1] == 1
+	r.State = PreACState(m.Data[0])
 	r.raw = m.Data
 }
 
-func (r *RegisterACOperStatus) Raw() string {
+func (r *RegisterPreACState) Raw() string {
 	return hex.EncodeToString(r.raw)
 }
 
-func (r *RegisterACOperStatus) String() string {
-	if r.Operating {
-		return "AC on"
+func (r *RegisterPreACState) String() string {
+	switch r.State {
+	case PreACOff: return "Pre-AC off"
+	case PreACOn: return "Pre-AC on"
+	case PreACTerminated: return "Pre-AC terminated (door opened or battery low?)"
+	default: return fmt.Sprintf("Pre-AC: unknown (%v)", r.State)
 	}
-	return "AC off"
 }
 
-func (r *RegisterACOperStatus) Register() byte {
-	return ACOperStatusRegister
+func (r *RegisterPreACState) Register() byte {
+	return PreACStateRegister
 }
 
 type RegisterACMode struct {


### PR DESCRIPTION
Unlike the previously used 0x1a register this register exposes a termination state: i.e. normal termination or an "abnormal" termination due to a door having been opened.

Writing `1` to `0x13` will clear the abnormal termination state.