### PR TITLE
correct climate durations to match protocol spec

### DIFF
--- a/cmd/mqtt.go
+++ b/cmd/mqtt.go
@@ -278,7 +278,7 @@ func (m *mqttClient) handleIncomingMqtt(mqtt_client mqtt.Client, msg mqtt.Messag
 		payload := strings.ToLower(string(msg.Payload()))
 
 		modeMap := map[string]byte{"off": 0x0, "OFF": 0x0, "cool": 0x1, "heat": 0x2, "windscreen": 0x3, "mode": 0x4}
-		durMap := map[string]byte{"10": 0x0, "20": 0x10, "30": 0x20, "on": 0x0, "off": 0x0}
+		durMap := map[string]byte{"10": 0x0, "20": 0x1, "30": 0x2, "on": 0x0, "off": 0x0}
 		parts := strings.Split(topic, "/")
 		mode, ok := modeMap[parts[len(parts)-1]]
 		if !ok {


### PR DESCRIPTION
According to the protocol documentation, 0x1 is 20 mins and 0x2 is 30 so change it to match that.

Based on my limited testing, the durations now work. I'll test a bit more but as I saw others having the same issue I wanted to get this PR created.