### PR TITLE
Make pcap dependency optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,14 @@ Contributions and PRs are welcome.
 
 #### Install PCAP dev libraries
 
- * Ensure you have install the libpcap-dev package
+ * Optionally, you may want to have libpcap-dev package installed (if building with `-tags pcap`.)
 
 #### Download, extract, and compile phev2mqtt
 
  * Download the phev2mqtt archive
  * Extract it
- * Go into its the top level directory and run *go build*
- * Verify it runs with *./phev2mqtt -h*
+ * Go into its the top level directory and run `go build`
+ * Verify it runs with `./phev2mqtt -h`
 
 ### Connecting to the vehicle.
 
@@ -238,10 +238,9 @@ then extract off the phone.
 *PCAP Remote* is a little more involved, but allows for live sniffing of the traffic.
 
 Once you have downloaded the PCAP file(s) from the phone, you can analyse them with
-the command *phev2mqtt decode pcap <filename>*. Adjust the verbosity level (-v)
-between 'info', 'debug' and 'trace' for more details.
+the command *phev2mqtt decode pcap <filename>*. First build a `phev2mqtt` with pcap features:
+`go build -tags pcap`; you will need libpcap for this. Adjust the verbosity level (`-v`) between
+`info`, `debug` and `trace` for more details.
 
-Additionally, the flag '--latency' will use the PCAP packet timestamps to decode
+Additionally, the flag `--latency` will use the PCAP packet timestamps to decode
 the packets with original timings which can help pinpoint app events.
-
-

--- a/cmd/file.go
+++ b/cmd/file.go
@@ -26,6 +26,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var securityKey *protocol.SecurityKey
+
 // fileCmd represents the file command
 var fileCmd = &cobra.Command{
 	Use:   "file",

--- a/cmd/pcap.go
+++ b/cmd/pcap.go
@@ -125,8 +125,6 @@ func processPayload(cmd *cobra.Command, data []byte, dir string) {
 	}
 }
 
-var securityKey *protocol.SecurityKey
-
 var regs = map[byte]string{}
 
 var pings bool

--- a/cmd/pcap.go
+++ b/cmd/pcap.go
@@ -14,6 +14,9 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
+
+//go:build pcap
+
 package cmd
 
 import (


### PR DESCRIPTION
Cross-compiling (for usually aarch64 SBCs) is quite a bit more difficult compared to the usual `env GOARCH=arm64 go build` that is possible without this dependency. Furthermore in my mind the pcap functionality caters to a pretty niche use-case that most of the users won't ever bother with.

In this PR the dependency becomes optional, simplifying the build and deployment while still making it possible to utilize the code in protocol investigation with binary produced by `go build -tags pcap`.