### PR TITLE
Cleaned up and improved logging

### DIFF
--- a/cmd/register.go
+++ b/cmd/register.go
@@ -17,7 +17,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package cmd
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/buxtronix/phev2mqtt/client"
@@ -73,7 +72,7 @@ func runRegister(cmd *cobra.Command, args []string) {
 	if err := cl.Start(); err != nil {
 		panic(err)
 	}
-	fmt.Printf("Client connected and started!\n")
+	log.Infof("Client connected and started!")
 
 	vinCh := make(chan string)
 
@@ -114,10 +113,10 @@ func runRegister(cmd *cobra.Command, args []string) {
 
 	reg := byte(0x10)
 	if cmd.Use == "unregister" {
-		fmt.Printf("Attempting to unregister from car (VIN: %s)...\n", vin)
+		log.Infof("Attempting to unregister from car (VIN: %s)...", vin)
 		reg = 0x15
 	} else {
-		fmt.Printf("Attempting to register to car (VIN: %s)...\n", vin)
+		log.Infof("Attempting to register to car (VIN: %s)...", vin)
 	}
 	if err := cl.SetRegister(reg, []byte{0x1}); err != nil {
 		log.Errorf("Failed to (un)register: %v", err)
@@ -125,7 +124,7 @@ func runRegister(cmd *cobra.Command, args []string) {
 	}
 	cl.Close()
 	time.Sleep(time.Second)
-	fmt.Printf("Success!\n")
+	log.Infof("Success!")
 }
 
 func init() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"os"
+	"fmt"
 	log "github.com/sirupsen/logrus"
 	"github.com/wercker/journalhook"
 	"github.com/spf13/cobra"
@@ -107,6 +108,6 @@ func initConfig() {
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
-		log.Infof( "Using config file: %s", viper.ConfigFileUsed())
+		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,18 +17,18 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package cmd
 
 import (
-	"fmt"
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 	"os"
-
+	log "github.com/sirupsen/logrus"
+	"github.com/wercker/journalhook"
+	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
 var (
-	cfgFile  string
-	logLevel string
-	logTimes bool
+	cfgFile   string
+	logLevel  string
+	logTimes  bool
+	logSyslog bool
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -43,9 +43,18 @@ var rootCmd = &cobra.Command{
 			panic(err)
 		}
 		log.SetLevel(level)
+		if logSyslog {
+			journalhook.Enable()
+		}
 		if logTimes {
 			log.SetFormatter(&log.TextFormatter{
 				FullTimestamp: true,
+			})
+		} else {
+			log.SetFormatter(&log.TextFormatter{
+				FullTimestamp: false,
+				DisableColors: true,
+				DisableTimestamp: true,
 			})
 		}
 	},
@@ -70,7 +79,8 @@ func init() {
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.phev2mqtt.yaml)")
 	rootCmd.PersistentFlags().StringVarP(&logLevel, "verbosity", "v", "info", "logging level to use")
-	rootCmd.PersistentFlags().BoolVarP(&logTimes, "log_timestamps", "t", false, "logging with timestamps")
+	rootCmd.PersistentFlags().BoolVarP(&logTimes, "log_timestamps", "t", false, "coloured logging with timestamps")
+	rootCmd.PersistentFlags().BoolVarP(&logSyslog, "log_syslog", "s", false, "plain logging to syslog instead of console")
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
@@ -97,6 +107,6 @@ func initConfig() {
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
-		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
+		log.Infof( "Using config file: %s", viper.ConfigFileUsed())
 	}
 }

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -18,12 +18,11 @@ package cmd
 
 import (
 	"encoding/hex"
-	"fmt"
 	"strings"
 	"time"
 
 	"github.com/buxtronix/phev2mqtt/client"
-	//	log "github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -94,12 +93,13 @@ func runSet(cmd *cobra.Command, args []string) {
 	if err := cl.Start(); err != nil {
 		panic(err)
 	}
-	fmt.Printf("Client connected and started!\nWaiting %d\n", waitTime.String())
+	log.Infof("Client connected and started!")
+	log.Infof("Waiting %d", waitTime.String())
 
 	time.Sleep(waitTime)
 
 	for _, reg := range setRegisters {
-		fmt.Printf("Setting register 0x%x to 0x%s\n", reg.register, hex.EncodeToString(reg.value))
+		log.Infof("Setting register 0x%x to 0x%s", reg.register, hex.EncodeToString(reg.value))
 		if err := cl.SetRegister(reg.register, reg.value); err != nil {
 			panic(err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/buxtronix/phev2mqtt
 go 1.16
 
 require (
+	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf // indirect
 	github.com/d4l3k/messagediff v1.2.1 // indirect
 	github.com/eclipse/paho.mqtt.golang v1.3.5
 	github.com/google/btree v1.0.0 // indirect
@@ -10,6 +11,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/viper v1.8.1
+	github.com/wercker/journalhook v0.0.0-20230927020745-64542ffa4117
 	golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	gopkg.in/d4l3k/messagediff.v1 v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
+github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf h1:iW4rZ826su+pqaw19uhpSCzhj44qo35pNgKFGqzDKkU=
+github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/d4l3k/messagediff v1.2.1 h1:ZcAIMYsUg0EAp9X+tt8/enBE/Q8Yd5kzPynLyKptt9U=
@@ -245,6 +247,8 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/wercker/journalhook v0.0.0-20230927020745-64542ffa4117 h1:67A5tweHp3C7osHjrYsy6pQZ00bYkTTttZ7kiOwwHeA=
+github.com/wercker/journalhook v0.0.0-20230927020745-64542ffa4117/go.mod h1:XCsSkdKK4gwBMNrOCZWww0pX6AOt+2gYc5Z6jBRrNVg=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/protocol/message.go
+++ b/protocol/message.go
@@ -236,7 +236,7 @@ func NewFromBytes(data []byte, key *SecurityKey) []*PhevMessage {
 		p.OriginalXored = data[offset : offset+len(dat)]
 		p.Xor = xor
 		if err != nil {
-			fmt.Printf("decode error: %v\n", err)
+			log.Errorf("decode error: %v\n", err)
 			break
 		}
 		msgs = append(msgs, p)

--- a/protocol/raw.go
+++ b/protocol/raw.go
@@ -2,7 +2,6 @@ package protocol
 
 import (
 	"encoding/hex"
-	"fmt"
 	log "github.com/sirupsen/logrus"
 	"math/rand"
 )
@@ -158,7 +157,7 @@ func ValidateChecksum(message []byte) bool {
 // plus any trailing data.
 func ValidateAndDecodeMessage(message []byte) ([]byte, byte, []byte) {
 	if len(message) < 4 {
-		fmt.Printf("Short msg\n")
+		log.Debugf("Short msg\n")
 		return nil, 0, nil
 	}
 	xor := message[2]
@@ -167,7 +166,7 @@ func ValidateAndDecodeMessage(message []byte) ([]byte, byte, []byte) {
 		xor ^= 1
 		msg = XorMessageWith(message, xor)
 		if !ValidateChecksum(msg) {
-			fmt.Printf("Bad sum for (%s)\n", hex.EncodeToString(message))
+			log.Debugf("Bad sum for (%s)\n", hex.EncodeToString(message))
 			return nil, 0, nil
 		}
 	}


### PR DESCRIPTION
1. Added possibility to log to syslog
   This is handy do distinguish message levels when phev2mqtt is running as a service
2. Replaced fmt.Printf with log.Infof/log.Debugf 
    Makes it easier to control the verbosity of program output
3. Do not flood the log with the same error when the connection is lost