### PR TITLE
Improve MQTT handling and use cache for incorrect battery and charge remaining readings

### DIFF
--- a/cmd/mqtt.go
+++ b/cmd/mqtt.go
@@ -457,7 +457,15 @@ func (m *mqttClient) publishRegister(msg *protocol.PhevMessage) {
 		}
 	case *protocol.RegisterChargeStatus:
 		m.publish("/charge/charging", boolOnOff[reg.Charging])
-		m.publish("/charge/remaining", fmt.Sprintf("%d", reg.Remaining))
+		if reg.Remaining < 1000 {
+			m.publish("/charge/remaining", fmt.Sprintf("%d", reg.Remaining))
+		} else {
+			log.Debugf("Ignoring charge remanining reading: %v", reg.Remaining)
+			if cache := m.mqttData["/charge/remaining"]; cache != "" {
+				m.publish("/charge/remaining", cache)
+				log.Debugf("Publishing last best known charge remaining reading: %v", cache)
+			}
+		}
 	case *protocol.RegisterDoorStatus:
 		m.publish("/door/locked", boolOpen[!reg.Locked])
 		m.publish("/door/rear_left", boolOpen[reg.RearLeft])


### PR DESCRIPTION
1. Bypass cache when sending MQTT messages
    This fixes the problem of sensor data unavailable after HASS or MQTT broker restart
2. Send persistent HASS discovery messages, report discovery message send errors 
3. Send cached values of battery level and charge remaining in case the reading from vehicle are incorrect