### PR TITLE
Added command line parameter to disable PHEV register settings via MQTT

### DIFF
--- a/cmd/mqtt.go
+++ b/cmd/mqtt.go
@@ -44,6 +44,7 @@ Status data from the car is passed to the MQTT topics, and also some commands fr
 are sent to control certain aspects of the car. See the phev2mqtt Github page for
 more details on the topics.
 `,
+	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		mc := &mqttClient{climate: new(climate)}
 		return mc.Run(cmd, args)


### PR DESCRIPTION
This is useful feature for setups where remote vehicle control is not needed.
It will prevent unintentional communication and increase the security